### PR TITLE
Bump version to 0.13.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ _bin/
 _tmp/
 .gows*
 bitrise-plugins-analytics
+.idea/

--- a/bitrise-plugin.yml
+++ b/bitrise-plugin.yml
@@ -6,9 +6,9 @@ description: |-
 
   The sent data only contains information about steps (id, version, runtime, error), NO logs or other data is included.
 executable:
-  osx: https://github.com/bitrise-io/bitrise-plugins-analytics/releases/download/0.12.7/bitrise-plugins-analytics-Darwin-x86_64
-  osx-arm64: https://github.com/bitrise-io/bitrise-plugins-analytics/releases/download/0.12.7/bitrise-plugins-analytics-Darwin-arm64
-  linux: https://github.com/bitrise-io/bitrise-plugins-analytics/releases/download/0.12.7/bitrise-plugins-analytics-Linux-x86_64
+  osx: https://github.com/bitrise-io/bitrise-plugins-analytics/releases/download/0.13.0/bitrise-plugins-analytics-Darwin-x86_64
+  osx-arm64: https://github.com/bitrise-io/bitrise-plugins-analytics/releases/download/0.13.0/bitrise-plugins-analytics-Darwin-arm64
+  linux: https://github.com/bitrise-io/bitrise-plugins-analytics/releases/download/0.13.0/bitrise-plugins-analytics-Linux-x86_64
 trigger: DidFinishRun
 requirements:
 - tool: bitrise

--- a/integration_tests/version_test.go
+++ b/integration_tests/version_test.go
@@ -9,7 +9,7 @@ import (
 )
 
 const (
-	expectedVersion = "0.12.7"
+	expectedVersion = "0.13.0"
 )
 
 func Test_VersionTest(t *testing.T) {

--- a/version/version.go
+++ b/version/version.go
@@ -1,4 +1,4 @@
 package version
 
 // VERSION ...
-const VERSION = "0.12.7"
+const VERSION = "0.13.0"


### PR DESCRIPTION
This PR bumps the plugin version to 0.13.0, to release the [analytics base URL update](https://github.com/bitrise-io/bitrise-plugins-analytics/commit/790f5f4e0adffb61cc526568d03ca874dfb65e08).