### PR TITLE
Update goreleaser config

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -21,11 +21,11 @@ archives:
   # GitHub release should contain the raw binaries (no zip or tar.gz)
 - format: binary
   # Name format should match the curl install script
-  name_template: "{{ .ProjectName }}-{{ .Os }}-{{ .Arch }}"
-  replacements:
-    darwin: Darwin
-    linux: Linux
-    amd64: x86_64
+  name_template: >-
+    {{ .ProjectName }}-
+    {{- title .Os }}-
+    {{- if eq .Arch "amd64" }}x86_64
+    {{- else }}{{ .Arch }}{{ end }}
 
 release:
   github:


### PR DESCRIPTION
This PR updates `goreleaser` config because a recent release has failed with this issue:

```

This step requires "goreleaser" to be available, but it is not installed.
Installing package: brew "install" "goreleaser"...
 * [OK] goreleaser installed
 * [OK] Step dependency (goreleaser) installed, available.
+ goreleaser release
  • starting release...
  ⨯ release failed after 0s                  error=yaml: unmarshal errors:
  line 25: field replacements not found in type config.Archive
exit status 1
```

A similar change was needed for stepman recently: https://github.com/bitrise-io/stepman/pull/317/files#diff-7326b55c062b0f46fe9e39aace0a25f4515cf206040fb91a6fd2cae839f5e826